### PR TITLE
Feat : users can now use frames to make grids of components 

### DIFF
--- a/src/generator/model-builder.ts
+++ b/src/generator/model-builder.ts
@@ -7,6 +7,8 @@ import {ImageComponent} from "../model/components/image-component.js";
 import type {Component} from "../model/components/component.abstract.js";
 import {CodeComponent} from "../model/components/code-component.js";
 import {NestedSlide} from "../model/nestedSlide.js";
+import {FrameComponent} from "../model/components/frame-component.js";
+import {Direction} from "../model/enums/direction.enum.js";
 
 type ComponentBuilder = (ast:any) => Component;
 
@@ -16,7 +18,18 @@ const COMPONENT_BUILDERS : Record<string, ComponentBuilder> = {
   },
   VideoComponent: (ast) => new VideoComponent(ast.src, ast.autoPlay, Size.DEFAULT),
   ImageComponent: (ast) => new ImageComponent(ast.src, ast.alt, Size.DEFAULT),
-  CodeComponent: (ast) => new CodeComponent(dedent(ast.value), ast.language, Size.DEFAULT)
+  CodeComponent: (ast) => new CodeComponent(dedent(ast.value), ast.language, Size.DEFAULT),
+  FrameComponent: (ast) => {
+    const components = ast.components.map((c: any) => {
+      const builder = COMPONENT_BUILDERS[c.$type];
+      if (!builder) {
+        throw new Error(`Unknown component type: ${c.$type}`);
+      }
+      return builder(c);
+    });
+    const direction = ast.direction === "horizontal" ? Direction.HORIZONTAL : Direction.VERTICAL;
+    return new FrameComponent(components, direction, Size.DEFAULT);
+  }
 }
 
 

--- a/src/generator/reveal-visitor.ts
+++ b/src/generator/reveal-visitor.ts
@@ -11,6 +11,8 @@ import { marked } from "marked";
 import type {VideoComponent} from "../model/components/video-component.js";
 import type {ImageComponent} from "../model/components/image-component.js";
 import type {NestedSlide} from "../model/nestedSlide.js";
+import type { FrameComponent } from "../model/components/frame-component.js";
+import { Direction } from "../model/enums/direction.enum.js";
 
 export class RevealVisitor implements Visitor {
 
@@ -41,6 +43,20 @@ export class RevealVisitor implements Visitor {
         display: inline-block;  
         text-align: left;
         padding:10px;
+    }
+    
+    .vertical-frame {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .horizontal-frame {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 10px;
     }
   </style>
 
@@ -122,7 +138,23 @@ export class RevealVisitor implements Visitor {
     const content = `<video controls ${videoComponent.autoPlay ? "data-autoplay" : ""} src="${videoComponent.src}"></video>`;
     this.currentSlideContent.push(content);
   }
-  visitFrameComponent(): void { }
+
+  visitFrameComponent(FrameComponent: FrameComponent): void {
+    const frameClass = FrameComponent.direction === Direction.VERTICAL ? "vertical-frame" : "horizontal-frame";
+    let frameContent = [];
+
+    for (const component of FrameComponent.components) {
+      component.accept(this);
+      frameContent.push(this.currentSlideContent.pop());
+    }
+
+    this.currentSlideContent.push(`
+      <div class="${frameClass}">
+        ${frameContent.join("\n")}
+      </div>
+    `);
+  }
+
   visitTemplate(): void { }
   visitCodeComponent(codeComponent: CodeComponent): void {
     this.currentSlideContent.push(`

--- a/src/input/demo.sml
+++ b/src/input/demo.sml
@@ -38,7 +38,16 @@ diapo {
   }
 
   slide{
-    video "./assets/rick-roll.mp4"
+    frame vertical {
+      frame horizontal {
+        text "top left"
+        text "top right"
+      }
+      frame horizontal {
+        text "bottom left"
+        text "bottom right"
+      }
+    }
   }
 
   slide{

--- a/src/language-server/slide-ml.langium
+++ b/src/language-server/slide-ml.langium
@@ -5,6 +5,10 @@ terminal STRING:
   '"' ('\\' . | !('\\' | '"'))* '"'
 ;
 
+terminal DIRECTION: 
+  'vertical' | 'horizontal'
+;
+
 terminal ID:
   /[a-zA-Z_][a-zA-Z0-9_]*/
 ;
@@ -38,7 +42,8 @@ NestedSlide:
 ;
 
 Component:
-  TextComponent | VideoComponent | ImageComponent | CodeComponent
+  TextComponent | VideoComponent | ImageComponent | CodeComponent |
+  FrameComponent
 ;
 
 TextComponent:
@@ -57,4 +62,10 @@ CodeComponent:
     'code'
     'language' language=ID
     value=STRING
+;
+
+FrameComponent:
+  'frame' direction=DIRECTION '{'
+    components+=Component*
+  '}'
 ;


### PR DESCRIPTION
usage : 

slide {
 frame vertical {
      frame horizontal {
        text "top left"
        text "top right"
      }
      frame horizontal {
        text "bottom left"
        text "bottom right"
      }
    }
}

result : 
<img width="1362" height="943" alt="image" src="https://github.com/user-attachments/assets/20b7a589-05b4-414c-8cd4-59103ccb5f01" />
